### PR TITLE
chore(workflows): fix Node 20 warning and optimize rust-cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2.9.1
         with:
           shared-key: test
-          cache-targets: false
+          key: ${{ matrix.target }}
+          cache-targets: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - uses: cargo-bins/cargo-binstall@main
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           version: 10.1.0
           arch_list: x86_64,aarch64,riscv64,loongarch64
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2.9.1
         with:
           shared-key: test
           cache-targets: false


### PR DESCRIPTION
## Summary

- upgrade `Swatinem/rust-cache` to `v2.9.1` to avoid deprecated Node.js 20 actions
- enable target-specific rust cache for CI matrix builds
- only save cache on `main` to reduce cache churn from PR branches

## Details

- set `key: ${{ matrix.target }}` to isolate caches per target
- set `cache-targets: true` to cache compiled artifacts
- set `save-if: ${{ github.ref == 'refs/heads/main' }}` for more stable cache reuse
