### PR TITLE
ci: use container image to simplify test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,25 +26,18 @@ jobs:
           - arch: x86_64
             target: x86_64-unknown-none
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}-container:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-
-      - &setup-libudenv
-        uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: libudev-dev
-          version: 1.0
+          persist-credentials: false
 
-      - name: Install toolchain
-        run: rustup show
       - name: Check rust version
         run: rustc --version --verbose
-
-      - name: Setup QEMU
-        uses: arceos-org/setup-qemu@v1
-        with:
-          version: 10.1.0
-          arch_list: x86_64,aarch64,riscv64,loongarch64
 
       - uses: Swatinem/rust-cache@v2.9.1
         with:
@@ -53,20 +46,6 @@ jobs:
           cache-targets: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - uses: cargo-bins/cargo-binstall@main
-
-      - name: Install ostool
-        run: cargo binstall ostool --no-confirm --force
-
-      - name: Install cargo-binutils
-        run: |
-          cargo-binstall \
-            --pkg-url="{ repo }/releases/download/v{ version }/{ target }.tar.gz" \
-            --pkg-fmt="tgz" \
-            cargo-binutils --no-confirm --force
-
-      - name: Add Target
-        run: rustc --version
       - name: Check code format
         run: cargo fmt --all -- --check
 


### PR DESCRIPTION
## Summary

Use the container image published from this repository to replace the manual QEMU/ostool installation steps in the test workflow.

### Changes

- Add `container:` configuration using `ghcr.io/${{ github.repository }}-container:latest`
- Remove `setup-qemu`, `cargo-binstall`, `apt install libudev-dev`, and related steps
- The container image already includes: QEMU 10.2.1, ostool, cargo-binutils, cargo-hack, and all required targets

### Benefits

- Simplified CI workflow: ~15 steps → ~8 steps
- Faster CI execution (no repeated tool installation)
- Consistent environment across all test jobs