### PR TITLE
[codex] fix real-board workflow for ostool board run

### DIFF
--- a/.board.toml
+++ b/.board.toml
@@ -1,0 +1,3 @@
+board_type = "orangepi5plus"
+fail_regex = []
+success_regex = []

--- a/.board.toml
+++ b/.board.toml
@@ -1,3 +1,0 @@
-board_type = "orangepi5plus"
-fail_regex = []
-success_regex = []

--- a/.github/workflows/board.toml
+++ b/.github/workflows/board.toml
@@ -1,0 +1,3 @@
+board_type = "orangepi5plus"
+fail_regex = []
+success_regex = ["All tests passed!"]

--- a/.github/workflows/test-real.yml
+++ b/.github/workflows/test-real.yml
@@ -8,16 +8,16 @@ jobs:
     strategy:
       matrix:
         include:
-          - board: phytiumpi
+          - board: PhytiumPi
             suit_name: el1
             config: "./test-suit/timer/aarch64.toml"
-          - board: phytiumpi
+          - board: PhytiumPi
             suit_name: smp
             config: "./test-suit/smp/aarch64.toml"
-          - board: roc-rk3568-pc
+          - board: ROC-RK3568-PC
             suit_name: el1
             config: "./test-suit/timer/aarch64.toml"
-          - board: roc-rk3568-pc
+          - board: ROC-RK3568-PC
             suit_name: smp
             config: "./test-suit/smp/aarch64.toml"
 
@@ -25,7 +25,7 @@ jobs:
     runs-on:
       - self-hosted
       - linux
-      - ${{ matrix.board }}
+      - board
 
     steps:
       - name: Clean up workspace
@@ -40,10 +40,9 @@ jobs:
           clean: true
 
       - name: Install dependencies
-        run: cargo +stable install ostool --version ^0.8
+        run: cargo +stable install ostool --version ^0.12
 
       - name: Run tests
         run: |
-          echo $BOARD_POWER_RESET
           export RUST_LOG=debug
-          ostool run -c ${{ matrix.config }} uboot -u .github/workflows/uboot.toml
+          ostool board run -c ${{ matrix.config }} --board-config .github/workflows/board.toml -b ${{ matrix.board }}


### PR DESCRIPTION
## What changed
- update the real-board workflow to install `ostool` `^0.12`
- switch the run step to `ostool board run` with an explicit board config file
- normalize matrix board names and use the shared `board` runner label

## Why
The real-board workflow was still using the older `ostool run ... uboot` flow and legacy board labels. With the newer board-based interface, the job needs an explicit board selection and board config.

## Impact
This lets the real-board CI job use the current `ostool` board workflow and the expected board metadata.

## Root cause
The workflow configuration had not been updated after the `ostool` board execution model and board naming conventions changed.

## Validation
- reviewed the final diff against `main`
- confirmed the branch only changes `.github/workflows/test-real.yml` and `.github/workflows/board.toml`
- `actionlint` is not available in the local environment
